### PR TITLE
feat: add move feature for journal entries

### DIFF
--- a/src/components/journal/DeleteButton.tsx
+++ b/src/components/journal/DeleteButton.tsx
@@ -4,7 +4,6 @@ import { FiTrash2 } from "react-icons/fi";
 
 interface DeleteDialogProps {
   onDelete: () => void;
-  // onCancel: () => void;
 }
 
 export function DeleteButton({ onDelete }: DeleteDialogProps) {

--- a/src/components/journal/JournalDrawer.tsx
+++ b/src/components/journal/JournalDrawer.tsx
@@ -1,5 +1,7 @@
+import { toaster } from "@/components/ui/toaster";
 import { useGeneralSettings } from "@/hooks/useGeneralSettings";
 import { useJournal } from "@/hooks/useJournal";
+import { TOASTER_ID } from "@/types/settings";
 import { Box, Button, Drawer, HStack, Text, IconButton, VStack, Separator, Portal } from "@chakra-ui/react";
 import { format, addDays, subDays, isSameDay, parseISO } from "date-fns";
 import { useCallback, useEffect, useState } from "react";
@@ -25,14 +27,18 @@ export function JournalDrawer() {
   useKey(
     (event) => (event.metaKey || event.ctrlKey) && event.key === "j",
     (event) => {
+      toaster.dismiss(TOASTER_ID);
       event.preventDefault();
       setOpen((prev) => !prev);
     }
   );
 
-  const navigateToDay = useCallback((date: Date) => {
-    setSelectedDate(date);
-  }, [setSelectedDate]);
+  const navigateToDay = useCallback(
+    (date: Date) => {
+      setSelectedDate(date);
+    },
+    [setSelectedDate]
+  );
 
   const goToToday = useCallback(() => {
     setSelectedDate(new Date());

--- a/src/components/journal/JournalEntryItem.tsx
+++ b/src/components/journal/JournalEntryItem.tsx
@@ -20,7 +20,7 @@ export function JournalEntryItem({ entry }: JournalEntryItemProps) {
 
   const handleMove = useCallback(
     (dt: Date) => {
-      updateEntry(entry.id, { date: formatISO(dt, { format: "basic" }) });
+      updateEntry(entry.id, { date: formatISO(dt, { representation: "date" }) });
     },
     [updateEntry, entry.id]
   );

--- a/src/components/journal/JournalEntryItem.tsx
+++ b/src/components/journal/JournalEntryItem.tsx
@@ -2,10 +2,12 @@ import { useColorModeValue } from "@/components/ui/color-mode";
 import { useJournal } from "@/hooks/useJournal";
 import { JournalEntry } from "@/types/journal";
 import { Box, HStack, Text, VStack, Editable } from "@chakra-ui/react";
+import { formatISO } from "date-fns";
 import { useCallback, useEffect, useState } from "react";
 import TimeAgo from "react-time-ago";
 import { useDebounce } from "react-use";
 import { DeleteButton } from "./DeleteButton";
+import { MoveButton } from "./MoveButton";
 
 interface JournalEntryItemProps {
   entry: JournalEntry;
@@ -15,6 +17,13 @@ export function JournalEntryItem({ entry }: JournalEntryItemProps) {
   const { deleteEntry, updateEntry } = useJournal();
   const [updatedValue, setUpdatedValue] = useState(entry.content);
   const bgColor = useColorModeValue("bg.muted", "bg.muted");
+
+  const handleMove = useCallback(
+    (dt: Date) => {
+      updateEntry(entry.id, { date: formatISO(dt, { format: "basic" }) });
+    },
+    [updateEntry, entry.id]
+  );
 
   const handleDelete = useCallback(() => {
     deleteEntry(entry.id);
@@ -42,6 +51,7 @@ export function JournalEntryItem({ entry }: JournalEntryItemProps) {
             <TimeAgo date={new Date(entry.updatedAt ?? entry.createdAt)} locale="en-US" />
           </Text>
           <HStack gap={1}>
+            <MoveButton onMove={handleMove} />
             <DeleteButton onDelete={handleDelete} />
           </HStack>
         </HStack>

--- a/src/components/journal/MoveButton.tsx
+++ b/src/components/journal/MoveButton.tsx
@@ -1,0 +1,83 @@
+import { Tooltip } from "@/components/ui/tooltip";
+import { Button, ButtonGroup, CloseButton, DatePicker, DateValue, Dialog, IconButton } from "@chakra-ui/react";
+import { useCallback, useState } from "react";
+import { LuMoveHorizontal } from "react-icons/lu";
+
+interface DeleteDialogProps {
+  onMove: (newDate: Date) => void;
+}
+
+export function MoveButton({ onMove }: DeleteDialogProps) {
+  const [newDate, setNewDate] = useState<DateValue[]>([]);
+
+  const handleMove = useCallback(() => {
+    if (newDate.length === 1) {
+      const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      onMove(newDate[0].toDate(timezone));
+    }
+  }, [newDate, onMove]);
+
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>
+        <IconButton aria-label="Move entry" variant="subtle" size="xs">
+          <Tooltip content="Move entry">
+            <LuMoveHorizontal />
+          </Tooltip>
+        </IconButton>
+      </Dialog.Trigger>
+      <Dialog.Backdrop />
+      <Dialog.Positioner>
+        <Dialog.Content width="xs">
+          <Dialog.CloseTrigger asChild>
+            <CloseButton size="sm" />
+          </Dialog.CloseTrigger>
+          <Dialog.Header>
+            <Dialog.Title>Pick date to move entry</Dialog.Title>
+          </Dialog.Header>
+          <Dialog.Body justifyItems="center">
+            <DatePicker.Root
+              size="xs"
+              value={newDate}
+              onValueChange={(e) => setNewDate(e.value)}
+              inline
+              hideOutsideDays
+              width="fit-content"
+            >
+              <DatePicker.Content unstyled>
+                <DatePicker.View view="day">
+                  <DatePicker.Header />
+                  <DatePicker.DayTable />
+                </DatePicker.View>
+                <DatePicker.View view="month">
+                  <DatePicker.Header />
+                  <DatePicker.MonthTable />
+                </DatePicker.View>
+                <DatePicker.View view="year">
+                  <DatePicker.Header />
+                  <DatePicker.YearTable />
+                </DatePicker.View>
+              </DatePicker.Content>
+            </DatePicker.Root>
+          </Dialog.Body>
+          <Dialog.Footer>
+            <ButtonGroup>
+              <Dialog.ActionTrigger asChild>
+                <Button variant="subtle">Cancel</Button>
+              </Dialog.ActionTrigger>
+              <Button
+                type="submit"
+                onClick={handleMove}
+                variant="subtle"
+                colorPalette="orange"
+                disabled={newDate.length === 0}
+              >
+                Move
+              </Button>
+            </ButtonGroup>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog.Positioner>
+    </Dialog.Root>
+  );
+}

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -1,14 +1,13 @@
+import { toaster } from "@/components/ui/toaster";
+import { useGeneralSettings } from "@/hooks/useGeneralSettings";
+import { TOASTER_ID } from "@/types/settings";
 import { Button, CloseButton, Dialog, HStack, Icon, Kbd, Portal, Tabs, Text } from "@chakra-ui/react";
 import { useEffect, useRef, useState } from "react";
 import { IoInformationCircleSharp } from "react-icons/io5";
 import { useKey } from "react-use";
-import { useGeneralSettings } from "../../hooks/useGeneralSettings";
-import { toaster } from "../ui/toaster";
 import { About } from "./About";
 import { License } from "./License";
 import { SettingsForm } from "./SettingsForm";
-
-const TOASTER_ID = "settings-toast";
 
 function ToastDescription() {
   const isMac = navigator.platform.toLowerCase().includes("mac");

--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -1,6 +1,6 @@
+import { useGeneralSettings } from "@/hooks/useGeneralSettings";
+import { isStartDay } from "@/types/start-day";
 import { Field, HStack, RadioGroup, Switch, VStack } from "@chakra-ui/react";
-import { useGeneralSettings } from "../../hooks/useGeneralSettings";
-import { isStartDay } from "../../types/start-day";
 
 export function SettingsForm() {
   const { settings, updateSettings } = useGeneralSettings();

--- a/src/hooks/useGeneralSettings.ts
+++ b/src/hooks/useGeneralSettings.ts
@@ -1,12 +1,5 @@
-import { StartDay } from "@/types/start-day";
+import { GeneralSettings } from "@/types/settings";
 import { useLocalStorage } from "@rm-hull/use-local-storage";
-
-export interface GeneralSettings {
-  startDay?: StartDay;
-  showTipsOnStartup?: boolean;
-  showJournalOnStartup?: boolean;
-  showBackgroundColorForWeekend?: boolean;
-}
 
 type UseGeneralSettingsReturnType = {
   settings: GeneralSettings | undefined;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,10 @@
+import { StartDay } from "./start-day";
+
+export const TOASTER_ID = "settings-toast";
+
+export interface GeneralSettings {
+  startDay?: StartDay;
+  showTipsOnStartup?: boolean;
+  showJournalOnStartup?: boolean;
+  showBackgroundColorForWeekend?: boolean;
+}


### PR DESCRIPTION
Allows users to reassign a journal entry to a different date via a date picker dialog.

```mermaid
graph TD
    A[JournalEntryItem] -->|Trigger| B(MoveButton)
    B -->|Select Date| C[DatePicker]
    C -->|onMove| D[updateEntry]
    D --> E[(Storage)]
```

- Add `MoveButton` component with `DatePicker`.
- Update `JournalEntryItem` to handle date migration.
- Centralize `TOASTER_ID` and move `GeneralSettings` to `types/settings.ts`.